### PR TITLE
Fixes #8 Add custom user-agent config file support

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataHenHQ/tillup/interceptors"
 	"github.com/DataHenHQ/tillup/logger"
 	"github.com/DataHenHQ/tillup/sessions"
+	"github.com/DataHenHQ/useragent"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -38,6 +39,16 @@ var serveCmd = &cobra.Command{
 		proxy.UAType = viper.GetString("ua-type")
 		if proxy.ForceUA {
 			fmt.Printf("Till is currently configured to override all User-Agent headers with random %v browsers\n", proxy.UAType)
+		}
+		uaConfigFile := viper.GetString("ua-config-file")
+		if uaConfigFile != "" {
+			err := useragent.LoadUAConfig(uaConfigFile)
+			if err != nil {
+				fmt.Println("Problem loading the ua-config-file:", err)
+				fmt.Println("aborting server")
+				return
+			}
+			fmt.Printf("Using ua-config-file to generate user-agent: %v\n", uaConfigFile)
 		}
 
 		// set the Token
@@ -180,6 +191,11 @@ func init() {
 
 	serveCmd.Flags().String("ua-type", "desktop", "Specify what kind of browser user-agent to generate. Values can either be \"desktop\" or \"mobile\"")
 	if err := viper.BindPFlag("ua-type", serveCmd.Flags().Lookup("ua-type")); err != nil {
+		log.Fatal("Unable to bind flag:", err)
+	}
+
+	serveCmd.Flags().String("ua-config-file", "", "Specify the path to a JSON file that contains a custom user-agent configuration.")
+	if err := viper.BindPFlag("ua-config-file", serveCmd.Flags().Lookup("ua-config-file")); err != nil {
 		log.Fatal("Unable to bind flag:", err)
 	}
 


### PR DESCRIPTION
This will allow users to provide a custom user-agent config file with only those user-agents that are useful for their needs by using the `--ua-config-file /path/to/custom-ua-config.json` flag or setting `ua-config-file: /path/to/custom-ua-config.json` on their `config.yaml` file.

For example, on issue #8, the user can download our [default user-agent config file](https://github.com/DataHenHQ/useragent/blob/main/config/default-ua-config.json), then remove `Internet Explorer` entry to prevent the target website **"Insecure Browser Detected!"** error message.

The git patch to create that custom user-agent config file without `Internet Explorer` would be
```
diff --git a/default-ua-config.json b/custom-ua-config.json
index f7257c1..9a56a83 100644
--- a/default-ua-config.json
+++ b/custom-ua-config.json
@@ -12,7 +12,6 @@
                         "signatures": ["Windows NT 6.1; Win64; x64"],
                         "probability": 0.1856,
                         "browser_ids": [
-                            "ie",
                             "edge",
                             "chrome",
                             "firefox",
@@ -26,7 +25,6 @@
                         "signatures": ["Windows NT 6.2; Win64; x64"],
                         "probability": 0.0106,
                         "browser_ids": [
-                            "ie",
                             "edge",
                             "chrome",
                             "firefox",
@@ -40,7 +38,6 @@
                         "signatures": ["Windows NT 6.3; Win64; x64"],
                         "probability": 0.0416,
                         "browser_ids": [
-                            "ie",
                             "edge",
                             "chrome",
                             "firefox",
@@ -54,7 +51,6 @@
                         "signatures": ["Windows NT 10.0; Win64; x64"],
                         "probability": 0.7400,
                         "browser_ids": [
-                            "ie",
                             "edge",
                             "chrome",
                             "firefox",
@@ -220,18 +216,6 @@
             }
         ],
         "browsers": {
-            "ie": {
-                "id": "ie",
-                "probability": 0.0119,
-                "ua_format": "Mozilla/5.0 (<os:kernel>; Trident/7.0; rv:11.0) like Gecko",
-                "variants": [
-                    {
-                        "id": "ie",
-                        "probability": 1,
-                        "data": {}
-                    }
-                ]
-            },
             "edge": {
                 "id": "edge",
                 "probability": 0.0261,

```